### PR TITLE
.github/workflows: drop macOS 10.15, add macOS 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16, 1.17, 1.18]
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019, windows-2022]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
The macOS 10.15 runners are deprecated [1]. Add macOS 12 in addition.

[1] https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/