### PR TITLE
go.mod: pin golang.org/x/sys module to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/tklauser/ps
 
 go 1.13
 
-require golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6
+require golang.org/x/sys v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
-golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
The Go project recently started tagging releases on the golang.org/x/* packages, see https://groups.google.com/g/golang-dev/c/5TazuUXQyHY

Use the tagged version of golang.org/x/sys to allow dependabot to updates this dependency going forward.