### PR TITLE
ci: update Go to 1.20, drop 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: [1.17, 1.18, 1.19]
+        go-version: ['1.18', '1.19', '1.20']
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
 
@@ -26,11 +26,11 @@ jobs:
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
 
     - name: Check formatting
-      if: ${{ matrix.go-version == '1.19' && matrix.os == 'ubuntu-22.04' }}
+      if: ${{ matrix.go-version == '1.20' && matrix.os == 'ubuntu-22.04' }}
       run: diff -u <(echo -n) <(gofmt -d .)
 
     - name: Check Go modules
-      if: ${{ matrix.go-version == '1.19' && matrix.os == 'ubuntu-22.04' }}
+      if: ${{ matrix.go-version == '1.20' && matrix.os == 'ubuntu-22.04' }}
       run: |
         go mod tidy
         git diff --exit-code


### PR DESCRIPTION
Run the formatting and module checks with 1.20.

Leave the staticcheck workflow on Go 1.19 for now until a version supporting Go 1.20 is released.