### PR TITLE
.github/workflows: test on macOS 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: ['1.18', '1.19', '1.20']
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
See https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/