### PR TITLE
Add Cirrus CI for FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,23 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+  GO_VERSION: go1.21.5
+
+freebsd_13_task:
+  freebsd_instance:
+    image_family: freebsd-13-2
+  install_script: |
+    pkg install -y go
+    GOBIN=$PWD/bin go install golang.org/dl/${GO_VERSION}@latest
+    bin/${GO_VERSION} download
+  build_script: bin/${GO_VERSION} build -v ./...
+  test_script: bin/${GO_VERSION} test -race ./...
+
+freebsd_14_task:
+  freebsd_instance:
+    image_family: freebsd-14-0
+  install_script: |
+    pkg install -y go
+    GOBIN=$PWD/bin go install golang.org/dl/${GO_VERSION}@latest
+    bin/${GO_VERSION} download
+  build_script: bin/${GO_VERSION} build -v ./...
+  test_script: bin/${GO_VERSION} test -race ./...


### PR DESCRIPTION
Test on the latest supported stable version, currently 13.2 and 14.0.