### PR TITLE
Use binary.NativeEndian on Solaris

### DIFF
--- a/process_solaris.go
+++ b/process_solaris.go
@@ -98,7 +98,7 @@ func newUnixProcess(pid int) (Process, error) {
 	defer f.Close()
 
 	var psi psinfo
-	err = binary.Read(f, binary.LittleEndian, &psi)
+	err = binary.Read(f, binary.NativeEndian, &psi)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Solaris might be running on big-endian systems when running on SPARC. This not a port available in gc but is available in gccgo.